### PR TITLE
/reply can be used for received messages

### DIFF
--- a/lib/src/main/kotlin/com/outdatedversion/survival/MessagingModule.kt
+++ b/lib/src/main/kotlin/com/outdatedversion/survival/MessagingModule.kt
@@ -10,26 +10,50 @@ import net.kyori.adventure.text.Component
 import org.bukkit.entity.Player
 import java.util.*
 
+/**
+ * Manages and registers the private messages commands, and recipient reply tracking
+ * @param privateMessageFormatter An instance of a private message formatter used to format private messages for players
+ */
 class MessagingModule(private val privateMessageFormatter: PrivateMessageFormatter) {
     private val recipientMap = hashMapOf<UUID, UUID>()
 
+    /**
+     * Register the /msg and the /reply commands with the server
+     * @param commandManager An instance of the server's command manager
+     */
     fun register(commandManager: PaperCommandManager) {
         commandManager.registerCommand(MessageCommand(this))
         commandManager.registerCommand(ReplyCommand(this))
     }
 
+    /**
+     * Sets the reply [recipient] for the [sender] in a map
+     */
     fun setReply(sender: UUID, recipient: UUID) {
         recipientMap[sender] = recipient
     }
 
+    /**
+     * Get the reply recipient UUID for the [sender]
+     * @param sender The sender of the message to get the reply recipient for as UUID
+     * @return UUID of the reply recipient
+     */
     fun getReply(sender: UUID): UUID? {
         return recipientMap[sender]
     }
 
+    /**
+     * Remove the reply recipient for the [sender]
+     */
     fun removeReply(sender: UUID) {
         recipientMap.remove(sender)
     }
 
+    /**
+     * Sends the appropriate message to the [sender] and [recipient]
+     * Play the notification sound, and save the reply recipients to the map
+     *
+     */
     fun sendPrivateMessage(sender: Player, recipient: Player, message: Component) {
         sender.sendMessage(privateMessageFormatter.apply(sender, recipient, message, true))
         recipient.sendMessage(privateMessageFormatter.apply(sender, recipient, message, false))
@@ -37,5 +61,9 @@ class MessagingModule(private val privateMessageFormatter: PrivateMessageFormatt
         recipient.playSound(Sound.sound(Key.key("block.note_block.pling"), Sound.Source.MASTER, 0.8f, 1f))
 
         setReply(sender.uniqueId, recipient.uniqueId)
+        // If the message recipient does not have a reply recipient set, set the reply recipient when they receive a message too
+        if (recipientMap[recipient.uniqueId] == null) {
+            setReply(recipient.uniqueId, sender.uniqueId)
+        }
     }
 }

--- a/lib/src/main/kotlin/com/outdatedversion/survival/Plugin.kt
+++ b/lib/src/main/kotlin/com/outdatedversion/survival/Plugin.kt
@@ -35,6 +35,7 @@ class Plugin: JavaPlugin() {
             DateTimeFormatter.ofPattern("h:mma v").withLocale(Locale.US).withZone(ZoneId.of("America/Chicago"))
         val defaultChatFormatter: ChatFormatter = VanillaChatFormatter(this, defaultTimeFormat)
         val chatProcessor = DefaultChatProcessor(defaultChatFormatter)
+        // Creates the private message formatter used to format private messages, then create the messaging module and pass that
         val privateMessageFormatter = PrivateMessageFormatter(this, defaultTimeFormat)
         val messagingModule = MessagingModule(privateMessageFormatter)
 
@@ -42,6 +43,7 @@ class Plugin: JavaPlugin() {
         this.commandManager.registerCommand(PointsOfInterestCommand(poiService, chatProcessor))
         this.commandManager.registerCommand(TimeZoneCommand(this))
         this.commandManager.registerCommand(IsSlimeChunkCommand())
+        // Register the /msg and /reply with the server and initiate its tracking
         messagingModule.register(this.commandManager)
 
 

--- a/lib/src/main/kotlin/com/outdatedversion/survival/command/MessageCommand.kt
+++ b/lib/src/main/kotlin/com/outdatedversion/survival/command/MessageCommand.kt
@@ -14,10 +14,18 @@ import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
-@CommandAlias("msg|m|tell|whisper")
+/**
+ * Handles the execution of the message commands
+ * Validates player send command arguments
+ * Find the player recipient
+ * Tell module to send message
+ */
+@CommandAlias("msg|m|tell|whisper|pm|dm")
 class MessageCommand(
     private val module: MessagingModule,
 ): BaseCommand() {
+
+
     @Default
     @CommandCompletion("@players @nothing")
     @Description("Sends a private message to another player.")

--- a/lib/src/main/kotlin/com/outdatedversion/survival/command/ReplyCommand.kt
+++ b/lib/src/main/kotlin/com/outdatedversion/survival/command/ReplyCommand.kt
@@ -14,6 +14,12 @@ import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
+/**
+ *  Handles the execution of the reply command used to reply to/with private messages.
+ *  Validates that reply can be used for the current sender if module has saved recipient
+ *  Checks if that player is online
+ *  Tells module to send the messages
+ */
 @CommandAlias("r|reply|rpl")
 class ReplyCommand(
     private val module: MessagingModule,

--- a/lib/src/main/kotlin/com/outdatedversion/survival/format/PrivateMessageFormatter.kt
+++ b/lib/src/main/kotlin/com/outdatedversion/survival/format/PrivateMessageFormatter.kt
@@ -12,7 +12,20 @@ import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
+/**
+ * This class is used to format the private messages send between a player sender and a player recipient
+ * @param plugin An instance of the plugin used to retrieve persistent data keys for the purpose of timezone displaying
+ * @param defaultTimeFormatter The default timezone to be used if the player does not already have a tracked timezone
+ */
 class PrivateMessageFormatter(private val plugin: Plugin, private val defaultTimeFormatter: DateTimeFormatter) {
+    /**
+     * Takes the message sender, its recipient, the message and whether the message should be formatted for the sender prospective or not (the recipient prospective)
+     * @param sender The player sender, the player attempting to send a message
+     * @param recipient The player recipient, the player the message is being sent to
+     * @param message The message Component containing the body of the message being sent to the recipient
+     * @param isSender Whether the message should be formatted for the sender prospective, or not, then for the recipient prospective
+     * @return Formatted component message ready to be sent the [isSender] player. Includes player name, colors, hovers, message body
+     */
     fun apply(sender: Player, recipient: Player, message: Component, isSender: Boolean): Component {
         //Implemented from the ChatFormatter
         val playerTimezone = if (isSender) sender.persistentDataContainer.get(


### PR DESCRIPTION
Allow a user who received a message to instantly use /reply to be able to reply to that user's message. This will only apply when the player doesn't currently have an active reply recipient.

Comments were added.